### PR TITLE
docs: Fixed feature typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ django-webhook-request-timestamp: 1697818014
 }
 ```
 
-### 🔥 Feautures
+### 🔥 Features
 - Automatically sends webhooks on model changes
 - Leverages Celery for processing
 - Webhook authentication using HMAC

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -36,7 +36,7 @@ django-webhook-request-timestamp: 1697818014
 }
 ```
 
-### 🔥 Feautures
+### 🔥 Features
 - Automatically sends webhooks on model changes
 - Leverages Celery for processing
 - Webhook authentication using HMAC


### PR DESCRIPTION
Fixed the "features" typos that are on the docs

![image](https://github.com/danihodovic/django-webhook/assets/73353716/ee6b3614-fff5-4e08-9c12-e7a0434b6b80)


Changed "Feautures" to "Features" in both `index.md` and `README.md`