### PR TITLE
Explicitly set the value of default_auto_field

### DIFF
--- a/django_webhook/apps.py
+++ b/django_webhook/apps.py
@@ -4,6 +4,7 @@ from django.apps import AppConfig
 
 class WebhooksConfig(AppConfig):
     name = "django_webhook"
+    default_auto_field = "django.db.models.AutoField"
 
     def ready(self):
         from django.conf import settings


### PR DESCRIPTION
The `makemigrations` command tries to create a new migration for the django-webhook dependency, to migrate from `AutoField` to `BigAutoField`. By setting this default value explicitly, the migration is not proposed anymore.