### PR TITLE
Update the signal dispatch identifier

### DIFF
--- a/django_webhook/signals.py
+++ b/django_webhook/signals.py
@@ -18,7 +18,7 @@ DELETE = "delete"
 
 
 class SignalListener:
-    def __init__(self, signal: ModelSignal, signal_name: str, model_cls: models.Model):
+    def __init__(self, signal: ModelSignal, signal_name: str, model_cls: type[models.Model]):
         valid_signals = ["post_save", "post_delete"]
         if signal_name not in valid_signals:
             raise ValueError(f"{signal} must be one of {valid_signals}")

--- a/django_webhook/signals.py
+++ b/django_webhook/signals.py
@@ -57,7 +57,7 @@ class SignalListener:
 
     @property
     def uid(self):
-        return f"django_webhook_{self.model_label}_{self.signal}"
+        return f"django_webhook_{self.model_label}_{self.signal_name}"
 
     @property
     def model_label(self):

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -4,6 +4,7 @@ import json
 from datetime import datetime, timedelta
 
 import pytest
+from django.db.models.signals import post_save, post_delete
 from django.test import override_settings
 from django.utils import timezone
 from freezegun import freeze_time
@@ -14,8 +15,11 @@ from django_webhook.test_factories import (
     WebhookSecretFactory,
     WebhookTopicFactory,
 )
+from django_webhook.signals import SignalListener
+
 from tests.model_data import TEST_JOIN_DATE, TEST_LAST_ACTIVE, TEST_USER
 from tests.models import Country, User
+
 
 pytestmark = pytest.mark.django_db
 
@@ -216,3 +220,16 @@ def test_caches_webhook_query_calls(mocker):
     with freeze_time(now + timedelta(minutes=1, seconds=1)):
         with assertNumQueries(2):  # pylint: disable=not-context-manager
             country.save()
+
+
+def test_signal_listener_uid():
+    assert (
+        SignalListener(signal=post_save, signal_name="post_save", model_cls=Country).uid
+        == "django_webhook_tests.Country_post_save"
+    )
+    assert (
+        SignalListener(
+            signal=post_delete, signal_name="post_delete", model_cls=Country
+        ).uid
+        == "django_webhook_tests.Country_post_delete"
+    )


### PR DESCRIPTION
For some reason during my dev, I wanted to disconnect the signals and I didn't manage to do it because of the `dispatch_uid` value that can be something like `django_webhook_tests.Country_<django.db.models.signals.ModelSignal object at 0x7d30e1214510>`.
We this change, we should now have `django_webhook_tests.Country_post_save`.
